### PR TITLE
Port to python3

### DIFF
--- a/python/EXASOL/__init__.py
+++ b/python/EXASOL/__init__.py
@@ -60,19 +60,19 @@ class timer:
         self._ws = ws
         self._name = name
     def __enter__(self):
-        self._t, self._c = time.time(), time.clock()
+        self._t, self._c = time.time(), time.process_time()
         self._pti, self._pci = 0, 0
         return self
     def __exit__(self, type, value, traceback):
-        t, c = time.time(), time.clock()
+        t, c = time.time(), time.process_time()
         x, y = self._ws._timers.get(self._name, (0, 0))
         self._ws._timers[self._name] = (x + (t - self._t - self._pti), y + (c - self._c - self._pci))
     def pausing(self):
         return timerpause(self)
     def pause(self):
-        self._pt, self._pc = time.time(), time.clock()
+        self._pt, self._pc = time.time(), time.process_time()
     def resume(self):
-        pt, pc = time.time(), time.clock()
+        pt, pc = time.time(), time.process_time()
         self._pti += pt - self._pt
         self._pci += pc - self._pc
 

--- a/python/EXASOL/test.py
+++ b/python/EXASOL/test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import sys, unittest, os, decimal, datetime, gc, time, zlib, json
 import cProfile, pstats
 import EXASOL
@@ -13,8 +11,10 @@ class EXASOLTest(unittest.TestCase):
     def setUpClass(self):
         self.ws = EXASOL.connect(DB_URL, 'sys', 'exasol', autocommit = True, useCompression = True)
         with self.ws.cursor() as c:
-            try: c.execute('OPEN SCHEMA test')
-            except: c.execute('CREATE SCHEMA test')
+            try:
+                c.execute('OPEN SCHEMA test')
+            except:
+                c.execute('CREATE SCHEMA test')
 
     @classmethod
     def tearDownClass(self):
@@ -33,10 +33,11 @@ def run(c):
     return int(time.time() - start)    
 ''')
             c.execute('SELECT sleep(60)')
-            print c.fetchall()
+            print(c.fetchall())
 
 class EXASOLDataTypeTests(EXASOLTest):
     def test_000_int(self):
+        pass
 
 
 class EXASOLEngineDBTest(EXASOLTest):
@@ -45,7 +46,7 @@ class EXASOLEngineDBTest(EXASOLTest):
             self.ws.columnar_mode = True
             self.assertEqual(c.execute('OPEN SCHEMA test'), 0)
             self.assertEqual(c.execute('SELECT * FROM cat'), 66)
-            self.assertTrue(u'ENGINETABLE' in c.fetchall()[0])
+            self.assertTrue('ENGINETABLE' in c.fetchall()[0])
 
     def test_001_fetchall_small(self):
         with self.ws.cursor() as c:
@@ -108,36 +109,36 @@ class EXASOLEngineDBTest(EXASOLTest):
             self.ws.columnar_mode = False
             self.assertEqual(c.execute('SELECT * FROM ENGINETABLE WHERE INT_INDEX > 0 AND INT_INDEX < 10 ORDER BY INT_INDEX'), 9)
             data = c.fetchall()
-            self.assertEqual(data[0], (1, u'42856.814', u'-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456, u'O', None, u'TEST                          ', u'z5uaaoai;HrakuxYr2;Zi.sp', u'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', u'1943-05-23', u'1982-11-01'))
-            self.assertEqual(data[-1], (9, u'-0.001', u'-5.385', 4662, -4748, -770164835, 137587790, -802185.79, 23.855287999999998, u'o', u'046144224708798261336938866   ', u'0718052103665962291399302     ', u'ABCDE', u'PohjJC2DXjA9gxQv', u'1980-12-03', u'1972-04-18'))
+            self.assertEqual(data[0], (1, '42856.814', '-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456, 'O', None, 'TEST                          ', 'z5uaaoai;HrakuxYr2;Zi.sp', 'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', '1943-05-23', '1982-11-01'))
+            self.assertEqual(data[-1], (9, '-0.001', '-5.385', 4662, -4748, -770164835, 137587790, -802185.79, 23.855287999999998, 'o', '046144224708798261336938866   ', '0718052103665962291399302     ', 'ABCDE', 'PohjJC2DXjA9gxQv', '1980-12-03', '1972-04-18'))
 
     def test_010_fetchall_small_parametersl_rows(self):
         with self.ws.cursor() as c:
             self.ws.columnar_mode = False
             self.assertEqual(c.execute('SELECT * FROM ENGINETABLE WHERE INT_INDEX > ? AND INT_INDEX < ? ORDER BY INT_INDEX', 0, 10), 9)
             data = c.fetchall()
-            self.assertEqual(data[0], (1, u'42856.814', u'-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456, u'O', None, u'TEST                          ', u'z5uaaoai;HrakuxYr2;Zi.sp', u'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', u'1943-05-23', u'1982-11-01'))
-            self.assertEqual(data[-1], (9, u'-0.001', u'-5.385', 4662, -4748, -770164835, 137587790, -802185.79, 23.855287999999998, u'o', u'046144224708798261336938866   ', u'0718052103665962291399302     ', u'ABCDE', u'PohjJC2DXjA9gxQv', u'1980-12-03', u'1972-04-18'))
+            self.assertEqual(data[0], (1, '42856.814', '-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456, 'O', None, 'TEST                          ', 'z5uaaoai;HrakuxYr2;Zi.sp', 'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', '1943-05-23', '1982-11-01'))
+            self.assertEqual(data[-1], (9, '-0.001', '-5.385', 4662, -4748, -770164835, 137587790, -802185.79, 23.855287999999998, 'o', '046144224708798261336938866   ', '0718052103665962291399302     ', 'ABCDE', 'PohjJC2DXjA9gxQv', '1980-12-03', '1972-04-18'))
 
     def test_011_fetchall_bigl_rows(self):
         with self.ws.cursor() as c:
             self.ws.columnar_mode = False
             self.assertEqual(c.execute('SELECT * FROM ENGINETABLE WHERE INT_INDEX > 0 AND INT_INDEX < 4000 ORDER BY INT_INDEX'), 3999)
             intindex = c.fetchall()
-            self.assertEqual(intindex[0][:9], (1, u'42856.814', u'-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456))
-            self.assertEqual(intindex[0][-9:], (4.827728e-28, 123.456, u'O', None, u'TEST                          ', u'z5uaaoai;HrakuxYr2;Zi.sp', u'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', u'1943-05-23', u'1982-11-01'))
-            self.assertEqual(intindex[-1][:9], (3999, u'1', u'41376.633', 4166, 5040, 781567016, -529930594, 1.4209716e-23, 8.953642e-34))
-            self.assertEqual(intindex[-1][-9:], (1.4209716e-23, 8.953642e-34, u'D', u'77trU,p                       ', u'TEST                          ', u'PTJ_7lDlI9,v7hU3oUjSwuQwN', u'jQMIV2zFP;QkDxprL', u'1942-12-07', u'2000-06-05'))
+            self.assertEqual(intindex[0][:9], (1, '42856.814', '-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456))
+            self.assertEqual(intindex[0][-9:], (4.827728e-28, 123.456, 'O', None, 'TEST                          ', 'z5uaaoai;HrakuxYr2;Zi.sp', 'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', '1943-05-23', '1982-11-01'))
+            self.assertEqual(intindex[-1][:9], (3999, '1', '41376.633', 4166, 5040, 781567016, -529930594, 1.4209716e-23, 8.953642e-34))
+            self.assertEqual(intindex[-1][-9:], (1.4209716e-23, 8.953642e-34, 'D', '77trU,p                       ', 'TEST                          ', 'PTJ_7lDlI9,v7hU3oUjSwuQwN', 'jQMIV2zFP;QkDxprL', '1942-12-07', '2000-06-05'))
 
     def test_012_fetchall_big_parametersl_rows(self):
         with self.ws.cursor() as c:
             self.ws.columnar_mode = False
             self.assertEqual(c.execute('SELECT * FROM ENGINETABLE WHERE INT_INDEX > ? AND INT_INDEX < ? ORDER BY INT_INDEX', 0, 4000), 3999)
             intindex = c.fetchall()
-            self.assertEqual(intindex[0][:9], (1, u'42856.814', u'-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456))
-            self.assertEqual(intindex[0][-9:], (4.827728e-28, 123.456, u'O', None, u'TEST                          ', u'z5uaaoai;HrakuxYr2;Zi.sp', u'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', u'1943-05-23', u'1982-11-01'))
-            self.assertEqual(intindex[-1][:9], (3999, u'1', u'41376.633', 4166, 5040, 781567016, -529930594, 1.4209716e-23, 8.953642e-34))
-            self.assertEqual(intindex[-1][-9:], (1.4209716e-23, 8.953642e-34, u'D', u'77trU,p                       ', u'TEST                          ', u'PTJ_7lDlI9,v7hU3oUjSwuQwN', u'jQMIV2zFP;QkDxprL', u'1942-12-07', u'2000-06-05'))
+            self.assertEqual(intindex[0][:9], (1, '42856.814', '-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456))
+            self.assertEqual(intindex[0][-9:], (4.827728e-28, 123.456, 'O', None, 'TEST                          ', 'z5uaaoai;HrakuxYr2;Zi.sp', 'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', '1943-05-23', '1982-11-01'))
+            self.assertEqual(intindex[-1][:9], (3999, '1', '41376.633', 4166, 5040, 781567016, -529930594, 1.4209716e-23, 8.953642e-34))
+            self.assertEqual(intindex[-1][-9:], (1.4209716e-23, 8.953642e-34, 'D', '77trU,p                       ', 'TEST                          ', 'PTJ_7lDlI9,v7hU3oUjSwuQwN', 'jQMIV2zFP;QkDxprL', '1942-12-07', '2000-06-05'))
 
     def test_013_fetchmany_smalll_rows(self):
         with self.ws.cursor() as c:
@@ -145,8 +146,8 @@ class EXASOLEngineDBTest(EXASOLTest):
             self.assertEqual(c.execute('SELECT * FROM ENGINETABLE WHERE INT_INDEX > 0 AND INT_INDEX < 10 ORDER BY INT_INDEX'), 9)
             data = c.fetchmany(size = 5)
             self.assertEqual(len(data), 5)
-            self.assertEqual(data[0], (1, u'42856.814', u'-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456, u'O', None, u'TEST                          ', u'z5uaaoai;HrakuxYr2;Zi.sp', u'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', u'1943-05-23', u'1982-11-01'))
-            self.assertEqual(data[-1], (5, u'-44807.806', u'-8.752', 16146, -8, -826950668, None, -357886640000000, 4.810994e+20, u'j', u'pmsB9ayzLfESkw                ', u'br8,yshVLHklywIX9NWfh         ', u'TEST', u'TEST', u'1992-08-05', u'1949-07-12'))
+            self.assertEqual(data[0], (1, '42856.814', '-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456, 'O', None, 'TEST                          ', 'z5uaaoai;HrakuxYr2;Zi.sp', 'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', '1943-05-23', '1982-11-01'))
+            self.assertEqual(data[-1], (5, '-44807.806', '-8.752', 16146, -8, -826950668, None, -357886640000000, 4.810994e+20, 'j', 'pmsB9ayzLfESkw                ', 'br8,yshVLHklywIX9NWfh         ', 'TEST', 'TEST', '1992-08-05', '1949-07-12'))
 
     def test_014_fetchmany_small_parametersl_rows(self):
         with self.ws.cursor() as c:
@@ -154,28 +155,28 @@ class EXASOLEngineDBTest(EXASOLTest):
             self.assertEqual(c.execute('SELECT * FROM ENGINETABLE WHERE INT_INDEX > ? AND INT_INDEX < ? ORDER BY INT_INDEX', 0, 10), 9)
             data = c.fetchmany(size = 5)
             self.assertEqual(len(data), 5)
-            self.assertEqual(data[0], (1, u'42856.814', u'-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456, u'O', None, u'TEST                          ', u'z5uaaoai;HrakuxYr2;Zi.sp', u'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', u'1943-05-23', u'1982-11-01'))
-            self.assertEqual(data[-1], (5, u'-44807.806', u'-8.752', 16146, -8, -826950668, None, -357886640000000, 4.810994e+20, u'j', u'pmsB9ayzLfESkw                ', u'br8,yshVLHklywIX9NWfh         ', u'TEST', u'TEST', u'1992-08-05', u'1949-07-12'))
+            self.assertEqual(data[0], (1, '42856.814', '-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456, 'O', None, 'TEST                          ', 'z5uaaoai;HrakuxYr2;Zi.sp', 'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', '1943-05-23', '1982-11-01'))
+            self.assertEqual(data[-1], (5, '-44807.806', '-8.752', 16146, -8, -826950668, None, -357886640000000, 4.810994e+20, 'j', 'pmsB9ayzLfESkw                ', 'br8,yshVLHklywIX9NWfh         ', 'TEST', 'TEST', '1992-08-05', '1949-07-12'))
 
     def test_015_fetchmany_bigl_rows(self):
         with self.ws.cursor() as c:
             self.ws.columnar_mode = False
             self.assertEqual(c.execute('SELECT * FROM ENGINETABLE WHERE INT_INDEX > 0 AND INT_INDEX < 4000 ORDER BY INT_INDEX'), 3999)
             intindex = c.fetchmany(size = 2997)
-            self.assertEqual(intindex[0][:9], (1, u'42856.814', u'-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456))
-            self.assertEqual(intindex[0][-9:], (4.827728e-28, 123.456, u'O', None, u'TEST                          ', u'z5uaaoai;HrakuxYr2;Zi.sp', u'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', u'1943-05-23', u'1982-11-01'))
-            self.assertEqual(intindex[-1][:9], (2997, u'24009.895', u'5.877', 15927, 6056, 241109333, -46335780, 0.017249234000000002, -0.7224116970000001))
-            self.assertEqual(intindex[-1][-9:], (0.017249234000000002, -0.7224116970000001, u'q', u'ndNoPjisbFsiLFTjuD1p2ePYO     ', None, u'TEST', u'34491219476324761945', u'1975-08-09', u'1965-08-21'))
+            self.assertEqual(intindex[0][:9], (1, '42856.814', '-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456))
+            self.assertEqual(intindex[0][-9:], (4.827728e-28, 123.456, 'O', None, 'TEST                          ', 'z5uaaoai;HrakuxYr2;Zi.sp', 'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', '1943-05-23', '1982-11-01'))
+            self.assertEqual(intindex[-1][:9], (2997, '24009.895', '5.877', 15927, 6056, 241109333, -46335780, 0.017249234000000002, -0.7224116970000001))
+            self.assertEqual(intindex[-1][-9:], (0.017249234000000002, -0.7224116970000001, 'q', 'ndNoPjisbFsiLFTjuD1p2ePYO     ', None, 'TEST', '34491219476324761945', '1975-08-09', '1965-08-21'))
 
     def test_016_fetchmany_big_parametersl_rows(self):
         with self.ws.cursor() as c:
             self.ws.columnar_mode = False
             self.assertEqual(c.execute('SELECT * FROM ENGINETABLE WHERE INT_INDEX > ? AND INT_INDEX < ? ORDER BY INT_INDEX', 0, 4000), 3999)
             intindex = c.fetchmany(size = 2997)
-            self.assertEqual(intindex[0][:9], (1, u'42856.814', u'-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456))
-            self.assertEqual(intindex[0][-9:], (4.827728e-28, 123.456, u'O', None, u'TEST                          ', u'z5uaaoai;HrakuxYr2;Zi.sp', u'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', u'1943-05-23', u'1982-11-01'))
-            self.assertEqual(intindex[-1][:9], (2997, u'24009.895', u'5.877', 15927, 6056, 241109333, -46335780, 0.017249234000000002, -0.7224116970000001))
-            self.assertEqual(intindex[-1][-9:], (0.017249234000000002, -0.7224116970000001, u'q', u'ndNoPjisbFsiLFTjuD1p2ePYO     ', None, u'TEST', u'34491219476324761945', u'1975-08-09', u'1965-08-21'))
+            self.assertEqual(intindex[0][:9], (1, '42856.814', '-26939.136', -5741, 14966, 8, -241360270, 4.827728e-28, 123.456))
+            self.assertEqual(intindex[0][-9:], (4.827728e-28, 123.456, 'O', None, 'TEST                          ', 'z5uaaoai;HrakuxYr2;Zi.sp', 'LqZbuT0uC4vQ._6cG5uLpZdTZW;dfZ', '1943-05-23', '1982-11-01'))
+            self.assertEqual(intindex[-1][:9], (2997, '24009.895', '5.877', 15927, 6056, 241109333, -46335780, 0.017249234000000002, -0.7224116970000001))
+            self.assertEqual(intindex[-1][-9:], (0.017249234000000002, -0.7224116970000001, 'q', 'ndNoPjisbFsiLFTjuD1p2ePYO     ', None, 'TEST', '34491219476324761945', '1975-08-09', '1965-08-21'))
 
 
 class EXASOLODBCTest(EXASOLTest):
@@ -224,7 +225,7 @@ class EXASOLODBCTest(EXASOLTest):
             for a, b in zip(w, o):
                 if type(a) == type(1) and type(b) == type(1.0):
                     a = float(a)
-                self.assertEqual(unicode(a), unicode(b))
+                self.assertEqual(str(a), str(b))
 
     @unittest.skip("disabled")
     def test_001_fetchall_perf_vs_odbc(self):
@@ -256,7 +257,7 @@ class EXASOLODBCTest(EXASOLTest):
 
             if sys.version_info.major >= 3:
                 conv = str
-            else: conv = unicode
+            else: conv = str
             for w, o in zip(r1, r2):
                 for a, b in zip(w, o):
                     if type(a) == type(1) and type(b) == type(1.0):


### PR DESCRIPTION
Tested with python3.8.6. All functional tests work, but I was not able
to run the performance tests. They also relied on time.clock() in several
places. This function is deprecated since version 3.3 and was removed
in version 3.8, because of highly platform specific behavior.
I replaced it with time.process_time() as there is no direct replacement.
This invalidates all measurement values in the performance tests.